### PR TITLE
Fix compilation with DMD v2.067.1.

### DIFF
--- a/xe/disk.d
+++ b/xe/disk.d
@@ -520,7 +520,7 @@ private template TestImpl(string what)
 			{
 				return _sectorCount;
 			}
-			override @property ulong firstPhysicalSector() { return 1; }
+			override @property ulong firstPhysicalSector() const { return 1; }
 		}
 
 	protected:
@@ -539,7 +539,7 @@ private template TestImpl(string what)
 			_data[pos .. pos + len] = buffer[0 .. len];
 		}
 
-		override uint doGetSizeOfSector(uint sector)
+		override uint doGetSizeOfSector(uint sector) const
 		{
 			return sector > _singleDensitySectors ? _sectorSize : 128;
 		}

--- a/xe/disk_impl/atr.d
+++ b/xe/disk_impl/atr.d
@@ -146,7 +146,7 @@ protected:
 		_stream.write(offset, buffer[0 .. len]);
 	}
 
-	override uint doGetSizeOfSector(uint sector)
+	override uint doGetSizeOfSector(uint sector) const
 	{
 		ulong offset;
 		uint size;

--- a/xe/disk_impl/idea.d
+++ b/xe/disk_impl/idea.d
@@ -86,7 +86,7 @@ protected:
 		_stream.write(streamPosition(sector), buffer[0 .. len]);
 	}
 
-	override uint doGetSizeOfSector(uint sector)
+	override uint doGetSizeOfSector(uint sector) const
 	{
 		if (_pi.clsize == PartitionSectorSize.B256)
 			return sector > 3 ? 256 : 128;

--- a/xe/disk_impl/msdos.d
+++ b/xe/disk_impl/msdos.d
@@ -54,9 +54,9 @@ class MsdosPartition : XePartition
 		return "MS-DOS partition (" ~ _typeString ~ ")";
 	}
 
-	override @property ulong physicalSectorCount() { return _entry.sectors; }
+	override @property ulong physicalSectorCount() const { return _entry.sectors; }
 
-	override @property ulong firstPhysicalSector() { return _entry.lbaFirst; }
+	override @property ulong firstPhysicalSector() const { return _entry.lbaFirst; }
 
 protected:
 	override size_t doReadSector(uint sector, ubyte[] buffer)
@@ -71,7 +71,7 @@ protected:
 		_stream.write(streamPosition(sector), buffer[0 .. len]);
 	}
 
-	override uint doGetSizeOfSector(uint sector) { return 512; }
+	override uint doGetSizeOfSector(uint sector) const { return 512; }
 
 private:
 	this(RandomAccessStream st, PartitionEntry entry)

--- a/xe/disk_impl/xfd.d
+++ b/xe/disk_impl/xfd.d
@@ -62,7 +62,7 @@ protected:
 		_stream.write(getOffsetOfSector(sector), buffer[0 .. len]);
 	}
 
-	override uint doGetSizeOfSector(uint sector)
+	override uint doGetSizeOfSector(uint sector) const
 	{
 		return sector > 3 ? _sectorSize : 128;
 	}


### PR DESCRIPTION
```
c:\0\a8\xedisk>make
 DMD  build/release/xebase.lib
 DMD  build/release/xedisk.lib
xe\disk.d(523): Error: function xe.disk.TestImpl!"Partition".TestImpl.firstPhysicalSector does not override any function, did you mean to override 'xe.disk.XePartition.firstPhysicalSector'?
xe\disk.d(542): Error: function xe.disk.TestImpl!"Partition".TestImpl.doGetSizeOfSector does not override any function, did you mean to override 'xe.disk.XeDisk.doGetSizeOfSector'?
xe\disk.d(564): Error: template instance xe.disk.TestImpl!"Partition" error instantiating
xe\disk.d(542): Error: function xe.disk.TestImpl!"Disk".TestImpl.doGetSizeOfSector does not override any function, did you mean to override 'xe.disk.XeDisk.doGetSizeOfSector'?
xe\disk.d(565): Error: template instance xe.disk.TestImpl!"Disk" error instantiating
xe\disk_impl\atr.d(149): Error: function xe.disk_impl.atr.AtrDisk.doGetSizeOfSector does not override any function, did you mean to override 'xe.disk.XeDisk.doGetSizeOfSector'?
xe\disk_impl\xfd.d(65): Error: function xe.disk_impl.xfd.XfdDisk.doGetSizeOfSector does not override any function, did you mean to override 'xe.disk.XeDisk.doGetSizeOfSector'?
xe\disk_impl\idea.d(89): Error: function xe.disk_impl.idea.IdeaPartition.doGetSizeOfSector does not override any function, did you mean to override 'xe.disk.XeDisk.doGetSizeOfSector'?
xe\disk_impl\msdos.d(57): Error: function xe.disk_impl.msdos.MsdosPartition.physicalSectorCount does not override any function, did you mean to override 'xe.disk.XePartition.physicalSectorCount'?
xe\disk_impl\msdos.d(59): Error: function xe.disk_impl.msdos.MsdosPartition.firstPhysicalSector does not override any function, did you mean to override 'xe.disk.XePartition.firstPhysicalSector'?
xe\disk_impl\msdos.d(74): Error: function xe.disk_impl.msdos.MsdosPartition.doGetSizeOfSector does not override any function, did you mean to override 'xe.disk.XeDisk.doGetSizeOfSector'?
win32.mk:65: recipe for target 'build/release/xedisk.lib' failed
make[1]: *** [build/release/xedisk.lib] Error 1
win32.mk:38: recipe for target 'release' failed
make: *** [release] Error 2

c:\0\a8\xedisk>dmd | head -2
DMD32 D Compiler v2.067.1
Copyright (c) 1999-2014 by Digital Mars written by Walter Bright

c:\0\a8\xedisk>make -v
GNU Make 4.0
Built for i686-pc-cygwin
Copyright (C) 1988-2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```
