### PR TITLE
Replace the removed std.string.inPattern

### DIFF
--- a/xe/fs_impl/mydos.d
+++ b/xe/fs_impl/mydos.d
@@ -21,6 +21,7 @@ along with xedisk.  If not, see <http://www.gnu.org/licenses/>.
 module xe.fs_impl.mydos;
 
 debug import std.stdio;
+import std.ascii;
 import std.exception;
 import std.typecons;
 import std.datetime;
@@ -861,7 +862,7 @@ class MydosFileSystem : XeFileSystem
 	body
 	{
 		name = name.toLower().tr("a-z0-9@.", "_", "sc");
-		if (name[0].inPattern("0-9"))
+		if (isDigit(name[0]))
 			name = "@" ~ name;
 		auto com = regex(r"^([^.]{1,8})[^.]*(\..{0,3})?.*$");
 		return replace(name, com, "$1$2");


### PR DESCRIPTION
	C:\0\a8\xedisk>dmd --version
	DMD32 D Compiler v2.092.0-dirty
	Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved written by Walter Bright

	C:\0\a8\xedisk>make BUILD=debug
	 DMD  build/debug/xedisk.lib
	...
	xe\fs_impl\mydos.d(864): Error: no property inPattern for type immutable(char)
	xe\fs_impl\mydos.d(855): Error: function xe.fs_impl.mydos.MydosFileSystem.adjustName label __returnLabel is undefined
	make: *** [win32.mk:66: build/debug/xedisk.lib] Error 1
